### PR TITLE
Add block child theme

### DIFF
--- a/wp-content/themes/tango-kingdom-child/assets/css/custom.css
+++ b/wp-content/themes/tango-kingdom-child/assets/css/custom.css
@@ -1,0 +1,18 @@
+.hero-slider{position:relative;height:60vh;overflow:hidden}
+.hero-slide{position:absolute;inset:0;opacity:0;transition:opacity .8s}
+.hero-slide.active{opacity:1}
+.hero-overlay{position:absolute;inset:0;display:flex;flex-direction:column;justify-content:center;align-items:center;color:#fff;background:rgba(0,0,0,.45);text-align:center}
+
+.cta-wrap{display:grid;gap:1rem;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));margin:2rem auto;max-width:1100px}
+.plan{position:relative;overflow:hidden;border-radius:10px;cursor:pointer}
+.plan-overlay{position:absolute;inset:0;display:flex;flex-direction:column;justify-content:center;align-items:center;color:#fff;background:rgba(0,0,0,.35)}
+.btn-primary .wp-block-button__link{background:#F28C38;color:#fff;padding:.5em 1.2em;border-radius:4px;font-weight:600}
+
+.section{padding:3rem 1rem}
+.section-title{text-align:center;color:#4CA76A;font-size:1.9rem;margin-bottom:2rem}
+.cards{display:grid;gap:1.3rem;grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
+.card{background:#fff;border-radius:8px;box-shadow:0 2px 8px rgba(0,0,0,.1);transition:transform .2s}
+.card:hover{transform:translateY(-3px)}
+.news-list{list-style:none;display:grid;gap:1rem;max-width:800px;margin:0 auto}
+.news-list li{background:#fff;padding:.9rem;border-radius:6px;box-shadow:0 2px 6px rgba(0,0,0,.1);display:flex;gap:.6rem}
+

--- a/wp-content/themes/tango-kingdom-child/assets/js/hero-slider.js
+++ b/wp-content/themes/tango-kingdom-child/assets/js/hero-slider.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const slides = document.querySelectorAll('.hero-slide');
+  if (!slides.length) return;
+  let i = 0;
+  setInterval(() => {
+    slides[i].classList.remove('active');
+    i = (i + 1) % slides.length;
+    slides[i].classList.add('active');
+  }, 5000);
+});
+

--- a/wp-content/themes/tango-kingdom-child/block-template-parts/footer.html
+++ b/wp-content/themes/tango-kingdom-child/block-template-parts/footer.html
@@ -1,0 +1,6 @@
+<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","alignItems":"center"}} -->
+<div class="wp-block-group"><!-- wp:navigation {"overlayMenu":"never"} /--><!-- wp:paragraph -->
+<p>© 2024</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+

--- a/wp-content/themes/tango-kingdom-child/block-template-parts/header.html
+++ b/wp-content/themes/tango-kingdom-child/block-template-parts/header.html
@@ -1,0 +1,4 @@
+<!-- wp:group {"layout":{"type":"flex","justifyContent":"space-between","alignItems":"center"}} -->
+<div class="wp-block-group"><!-- wp:site-logo {"width":48} /--><!-- wp:site-title /--><!-- wp:navigation /--></div>
+<!-- /wp:group -->
+

--- a/wp-content/themes/tango-kingdom-child/block-templates/front-page.html
+++ b/wp-content/themes/tango-kingdom-child/block-templates/front-page.html
@@ -1,0 +1,142 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:html -->
+<div class="hero-slider">
+  <img src="/wp-content/themes/tango-kingdom-child/assets/images/hero1.jpg" class="hero-slide active" alt="">
+  <img src="/wp-content/themes/tango-kingdom-child/assets/images/hero2.jpg" class="hero-slide" alt="">
+  <img src="/wp-content/themes/tango-kingdom-child/assets/images/hero3.jpg" class="hero-slide" alt="">
+  <div class="hero-overlay"><h1>Tango Kingdom</h1><p>自然と食のテーマパーク</p></div>
+</div>
+<!-- /wp:html -->
+
+<!-- wp:columns {"className":"cta-wrap"} -->
+<div class="wp-block-columns cta-wrap"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:cover {"url":"/wp-content/themes/tango-kingdom-child/assets/images/plan1.jpg","className":"plan"} -->
+<div class="wp-block-cover plan"><span aria-hidden="true" class="wp-block-cover__background"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"className":"plan-overlay"} -->
+<div class="wp-block-group plan-overlay"><!-- wp:heading {"textAlign":"center","level":3} -->
+<h3 class="has-text-align-center">Plan 1</h3>
+<!-- /wp:heading --></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:cover --></div>
+<!-- /wp:column --><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:cover {"url":"/wp-content/themes/tango-kingdom-child/assets/images/plan2.jpg","className":"plan"} -->
+<div class="wp-block-cover plan"><span aria-hidden="true" class="wp-block-cover__background"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"className":"plan-overlay"} -->
+<div class="wp-block-group plan-overlay"><!-- wp:heading {"textAlign":"center","level":3} -->
+<h3 class="has-text-align-center">Plan 2</h3>
+<!-- /wp:heading --></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:cover --></div>
+<!-- /wp:column --><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:cover {"url":"/wp-content/themes/tango-kingdom-child/assets/images/plan3.jpg","className":"plan"} -->
+<div class="wp-block-cover plan"><span aria-hidden="true" class="wp-block-cover__background"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"className":"plan-overlay"} -->
+<div class="wp-block-group plan-overlay"><!-- wp:heading {"textAlign":"center","level":3} -->
+<h3 class="has-text-align-center">Plan 3</h3>
+<!-- /wp:heading --></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:cover --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:group {"tagName":"section","className":"section","layout":{"contentSize":"1200px"},"anchor":"experience"} -->
+<section id="experience" class="wp-block-group section"><!-- wp:heading {"level":2,"className":"section-title"} -->
+<h2 class="section-title">体験</h2>
+<!-- /wp:heading -->
+<!-- wp:columns {"className":"cards"} -->
+<div class="wp-block-columns cards"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"className":"card"} -->
+<figure class="wp-block-image card"><img src="/wp-content/themes/tango-kingdom-child/assets/images/exp1.jpg" alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"className":"card"} -->
+<figure class="wp-block-image card"><img src="/wp-content/themes/tango-kingdom-child/assets/images/exp2.jpg" alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"className":"card"} -->
+<figure class="wp-block-image card"><img src="/wp-content/themes/tango-kingdom-child/assets/images/exp3.jpg" alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></section>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"section","className":"section","layout":{"contentSize":"1200px"},"anchor":"dog"} -->
+<section id="dog" class="wp-block-group section"><!-- wp:heading {"level":2,"className":"section-title"} -->
+<h2 class="section-title">愛犬と楽しむ</h2>
+<!-- /wp:heading -->
+<!-- wp:columns {"className":"cards"} -->
+<div class="wp-block-columns cards"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"className":"card"} -->
+<figure class="wp-block-image card"><img src="/wp-content/themes/tango-kingdom-child/assets/images/dog1.jpg" alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"className":"card"} -->
+<figure class="wp-block-image card"><img src="/wp-content/themes/tango-kingdom-child/assets/images/dog2.jpg" alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"className":"card"} -->
+<figure class="wp-block-image card"><img src="/wp-content/themes/tango-kingdom-child/assets/images/dog3.jpg" alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></section>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"section","className":"section","layout":{"contentSize":"1200px"},"anchor":"gourmet"} -->
+<section id="gourmet" class="wp-block-group section"><!-- wp:heading {"level":2,"className":"section-title"} -->
+<h2 class="section-title">グルメ</h2>
+<!-- /wp:heading -->
+<!-- wp:columns {"className":"cards"} -->
+<div class="wp-block-columns cards"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"className":"card"} -->
+<figure class="wp-block-image card"><img src="/wp-content/themes/tango-kingdom-child/assets/images/gourmet1.jpg" alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"className":"card"} -->
+<figure class="wp-block-image card"><img src="/wp-content/themes/tango-kingdom-child/assets/images/gourmet2.jpg" alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"className":"card"} -->
+<figure class="wp-block-image card"><img src="/wp-content/themes/tango-kingdom-child/assets/images/gourmet3.jpg" alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></section>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"section","className":"section","layout":{"contentSize":"1200px"},"anchor":"stay"} -->
+<section id="stay" class="wp-block-group section"><!-- wp:heading {"level":2,"className":"section-title"} -->
+<h2 class="section-title">宿泊</h2>
+<!-- /wp:heading -->
+<!-- wp:columns {"className":"cards"} -->
+<div class="wp-block-columns cards"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"className":"card"} -->
+<figure class="wp-block-image card"><img src="/wp-content/themes/tango-kingdom-child/assets/images/stay1.jpg" alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"className":"card"} -->
+<figure class="wp-block-image card"><img src="/wp-content/themes/tango-kingdom-child/assets/images/stay2.jpg" alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"className":"card"} -->
+<figure class="wp-block-image card"><img src="/wp-content/themes/tango-kingdom-child/assets/images/stay3.jpg" alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></section>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"section","className":"section","layout":{"contentSize":"1200px"},"anchor":"news"} -->
+<section id="news" class="wp-block-group section"><!-- wp:heading {"level":2,"className":"section-title"} -->
+<h2 class="section-title">お知らせ</h2>
+<!-- /wp:heading -->
+<!-- wp:list {"className":"news-list"} -->
+<ul class="news-list"><li>ニュース1</li><li>ニュース2</li><li>ニュース3</li></ul>
+<!-- /wp:list --></section>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"section","className":"section","layout":{"contentSize":"1200px"},"anchor":"access"} -->
+<section id="access" class="wp-block-group section"><!-- wp:heading {"level":2,"className":"section-title"} -->
+<h2 class="section-title">アクセス</h2>
+<!-- /wp:heading -->
+<!-- wp:html -->
+<iframe src="https://maps.google.com/?q=kyotango&output=embed" width="100%" height="450"></iframe>
+<!-- /wp:html --></section>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/wp-content/themes/tango-kingdom-child/block-templates/page-dog.html
+++ b/wp-content/themes/tango-kingdom-child/block-templates/page-dog.html
@@ -1,0 +1,29 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:html -->
+<div class="hero-slider">
+  <img src="/wp-content/themes/tango-kingdom-child/assets/images/dog-hero.jpg" class="hero-slide active" alt="">
+  <div class="hero-overlay"><h1>愛犬家ページ</h1><p>ワンちゃんと楽しむ施設情報</p></div>
+</div>
+<!-- /wp:html -->
+
+<!-- wp:group {"tagName":"section","className":"section","layout":{"contentSize":"1200px"}} -->
+<section class="wp-block-group section"><!-- wp:heading {"level":2,"className":"section-title"} -->
+<h2 class="section-title">ドッグラン</h2>
+<!-- /wp:heading -->
+<!-- wp:paragraph -->
+<p>広々としたドッグランで思い切り遊べます。</p>
+<!-- /wp:paragraph --></section>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"section","className":"section","layout":{"contentSize":"1200px"}} -->
+<section class="wp-block-group section"><!-- wp:heading {"level":2,"className":"section-title"} -->
+<h2 class="section-title">ドッグカフェ</h2>
+<!-- /wp:heading -->
+<!-- wp:list -->
+<ul><li>テラス席はペット同伴OK</li><li>愛犬向けメニューも充実</li></ul>
+<!-- /wp:list --></section>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->
+

--- a/wp-content/themes/tango-kingdom-child/block-templates/page-family.html
+++ b/wp-content/themes/tango-kingdom-child/block-templates/page-family.html
@@ -1,0 +1,37 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:html -->
+<div class="hero-slider">
+  <img src="/wp-content/themes/tango-kingdom-child/assets/images/family-hero.jpg" class="hero-slide active" alt="">
+  <div class="hero-overlay"><h1>ファミリーページ</h1><p>家族みんなで楽しもう</p></div>
+</div>
+<!-- /wp:html -->
+
+<!-- wp:group {"tagName":"section","className":"section","layout":{"contentSize":"1200px"}} -->
+<section class="wp-block-group section"><!-- wp:heading {"level":2,"className":"section-title"} -->
+<h2 class="section-title">体験プログラム</h2>
+<!-- /wp:heading -->
+<!-- wp:columns {"className":"cards"} -->
+<div class="wp-block-columns cards"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:paragraph -->
+<p>農業体験やクラフト体験など、季節ごとのイベントを開催。</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:paragraph -->
+<p>小さなお子様でも安心して参加できます。</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></section>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"section","className":"section","layout":{"contentSize":"1200px"}} -->
+<section class="wp-block-group section"><!-- wp:heading {"level":2,"className":"section-title"} -->
+<h2 class="section-title">おすすめメニュー</h2>
+<!-- /wp:heading -->
+<!-- wp:list -->
+<ul><li>地元食材を使ったレストラン</li><li>家族向けのバーベキューエリア</li></ul>
+<!-- /wp:list --></section>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->
+

--- a/wp-content/themes/tango-kingdom-child/functions.php
+++ b/wp-content/themes/tango-kingdom-child/functions.php
@@ -1,0 +1,14 @@
+<?php
+function tango_kingdom_child_setup() {
+    add_theme_support( 'wp-block-styles' );
+}
+add_action( 'after_setup_theme', 'tango_kingdom_child_setup' );
+
+function tango_kingdom_child_enqueue() {
+    wp_enqueue_style( 'twentytwentytwo', get_template_directory_uri() . '/style.css' );
+    wp_enqueue_style( 'tango-kingdom-custom', get_stylesheet_directory_uri() . '/assets/css/custom.css' );
+    wp_enqueue_script( 'hero-slider', get_stylesheet_directory_uri() . '/assets/js/hero-slider.js', array(), null, true );
+}
+add_action( 'wp_enqueue_scripts', 'tango_kingdom_child_enqueue' );
+?>
+

--- a/wp-content/themes/tango-kingdom-child/style.css
+++ b/wp-content/themes/tango-kingdom-child/style.css
@@ -1,0 +1,7 @@
+/*
+ Theme Name:     Tango Kingdom Child
+ Description:    Block child-theme for Tango Kingdom (FSE)
+ Template:       twentytwentytwo
+ Version:        1.0.0
+ Text Domain:    tango-kingdom-child
+*/

--- a/wp-content/themes/tango-kingdom-child/theme.json
+++ b/wp-content/themes/tango-kingdom-child/theme.json
@@ -1,0 +1,8 @@
+{
+  "version": 2,
+  "extends": "twentytwentytwo",
+  "settings": {
+    "layout": { "contentSize": "1200px" },
+    "color": { "duotone": [] }
+  }
+}


### PR DESCRIPTION
## Summary
- add `tango-kingdom-child` block theme for Full Site Editing
- enqueue parent theme style and custom assets
- create header/footer template parts
- add front page and dog/family page templates

## Testing
- `php -l wp-content/themes/tango-kingdom-child/functions.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684edbcdd37c83299b18727e12152350