### PR TITLE
Add block template front page

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -62,6 +62,9 @@ add_action( 'after_setup_theme', function(){
     register_nav_menus( [
         'header' => __( 'ヘッダーナビゲーション', 'tango-kingdom' ),
     ] );
+
+    // Allow block templates and template parts with fallback to PHP files.
+    add_theme_support( 'block-templates' );
 } );
 
 add_action('wp_enqueue_scripts', function(){

--- a/parts/footer.html
+++ b/parts/footer.html
@@ -1,0 +1,8 @@
+<!-- wp:group {"tagName":"footer","className":"footer footer--child"} -->
+<footer class="footer footer--child">
+  <div class="footer__inner">
+    <!-- wp:navigation {"menuSlug":"footer","className":"footer-nav"} /-->
+    <div class="site-info">&copy; <!-- wp:site-title /-->. All Rights Reserved.</div>
+  </div>
+</footer>
+<!-- /wp:group -->

--- a/parts/header.html
+++ b/parts/header.html
@@ -1,0 +1,12 @@
+<!-- wp:group {"tagName":"header","className":"header header--child"} -->
+<header class="header header--child">
+  <div class="header__inner">
+    <div class="logo-wrap">
+      <!-- wp:site-logo {"className":"logo-img"} /-->
+      <!-- wp:site-title {"className":"site-name"} /-->
+    </div>
+    <!-- wp:navigation {"menuSlug":"header","className":"header-menu"} /-->
+    <div class="lang"><a href="?lang=en">EN</a></div>
+  </div>
+</header>
+<!-- /wp:group -->

--- a/templates/front-page.html
+++ b/templates/front-page.html
@@ -1,0 +1,149 @@
+<!-- wp:template-part {"slug":"header"} /-->
+
+<!-- wp:group {"className":"main-visual main-visual-slider"} -->
+<div class="main-visual main-visual-slider">
+  <div class="slide">
+    <img src="assets/slider/dogrun.jpg" alt="">
+    <div class="slide-caption">
+      <h1>家族も愛犬も、とっておきの休日を</h1>
+      <p>丹後王国「食のみやこ」で自然・体験・グルメを満喫</p>
+    </div>
+  </div>
+  <div class="slide">
+    <img src="assets/slider/zoo_goat.jpg" alt="">
+    <div class="slide-caption">
+      <h1>家族も愛犬も、とっておきの休日を</h1>
+      <p>丹後王国「食のみやこ」で自然・体験・グルメを満喫</p>
+    </div>
+  </div>
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"nav","className":"category-grid"} -->
+<nav class="category-grid">
+  <a href="#experience">体験</a>
+  <a href="#dog">愛犬と楽しむ</a>
+  <a href="#gourmet">グルメ</a>
+  <a href="#stay">泊まる</a>
+  <a href="#news">新着情報</a>
+  <a href="#access">アクセス</a>
+</nav>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"section","className":"intro-cards","layout":{"type":"constrained"}} -->
+<section id="experience" class="intro-cards">
+  <h2>親子で楽しむ体験プログラム</h2>
+  <div class="card">
+    <img src="assets/cards/Sea_Tango-Kingdom-Shoku-no-Miyako-04-1024x683.webp" alt="ブルーベリー狩り">
+    <h3>収穫体験農園</h3>
+    <p>季節の野菜や果物を自分の手で収穫しよう。</p>
+    <a href="/farm/" class="btn">詳しく見る</a>
+  </div>
+  <div class="card">
+    <img src="assets/cards/COPO488_1.jpg" alt="芝すべり">
+    <h3>芝すべり</h3>
+    <p>全長70m！スリル満点のロングスライダー。</p>
+    <a href="/shiba-suberi/" class="btn">詳しく見る</a>
+  </div>
+  <div class="card">
+    <img src="assets/cards/zoo_sheep1.jpg" alt="小さな動物園">
+    <h3>ふれあいミニ動物園</h3>
+    <p>ヤギや羊、カメにエサやり体験。小さなお子様も安心。</p>
+    <a href="/zoo/" class="btn">詳しく見る</a>
+  </div>
+</section>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"section","className":"intro-cards light-bg","layout":{"type":"constrained"}} -->
+<section id="dog" class="intro-cards light-bg">
+  <h2>ワンちゃんも主役！愛犬サービス</h2>
+  <div class="card">
+    <img src="assets/cards/dogrun.jpg" alt="ドッグラン">
+    <h3>西日本最大級ドッグラン</h3>
+    <p>約2,300㎡の広さでリードを外して思いきりラン！</p>
+    <a href="/dogrun/" class="btn">詳しく見る</a>
+  </div>
+  <div class="card">
+    <img src="assets/cards/S__24444937_0.jpg" alt="小型犬エリア">
+    <h3>小型犬専用エリア</h3>
+    <p>安心のフェンス付き。飼い主同士の交流も。</p>
+    <a href="/pet/" class="btn">詳しく見る</a>
+  </div>
+  <div class="card">
+    <img src="assets/cards/f4744700fc934204928856307294cf83-650x484.jpg" alt="犬同伴OKカフェ">
+    <h3>犬同伴OKカフェ</h3>
+    <p>愛犬と一緒に食事が楽しめるカフェやレストランが複数あります。</p>
+    <a href="/dog-cafe/" class="btn">詳しく見る</a>
+  </div>
+</section>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"section","className":"intro-cards","layout":{"type":"constrained"}} -->
+<section id="gourmet" class="intro-cards">
+  <h2>丹後の恵みを味わう</h2>
+  <div class="card">
+    <img src="assets/cards/restaurant.png" alt="山と海 with 日本海牧場">
+    <h3>山と海 with 日本海牧場</h3>
+    <p>牧場直送ビーフと地場野菜で贅沢ランチ。</p>
+    <a href="/yamatoumi/" class="btn">詳しく見る</a>
+  </div>
+  <div class="card">
+    <img src="assets/cards/brewery.jpg" alt="クラフトビール工房">
+    <h3>地ビール工房</h3>
+    <p>ここでしか味わえない限定クラフトビール。</p>
+    <a href="https://tango-kingdom.com/business/products/tangokingdombeer" class="btn" target="_blank">詳しく見る</a>
+  </div>
+  <div class="card">
+    <img src="assets/cards/9e4d3f65c3e50c539400fe707946adf8-scaled.jpg" alt="トン’sキッチン BBQ">
+    <h3>トン’sキッチン BBQ</h3>
+    <p>ブランド豚と季節野菜を手ぶらでBBQ。</p>
+    <a href="/tons-kitchen/" class="btn">詳しく見る</a>
+  </div>
+</section>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"section","className":"intro-cards light-bg","layout":{"type":"constrained"}} -->
+<section id="stay" class="intro-cards light-bg">
+  <h2>宿泊プラン</h2>
+  <div class="card">
+    <img src="assets/cards/hotel.jpg" alt="ホテル丹後王国">
+    <h3>ホテル丹後王国</h3>
+    <p>レストラン＆温泉付き。家族旅行の拠点に。</p>
+    <a href="https://www.hotel-tango-kingdom.com/" class="btn" target="_blank">詳細ページ（外部リンク）</a>
+  </div>
+  <div class="card">
+    <img src="assets/cards/image-type-a.png" alt="愛犬同伴グランピング">
+    <h3>愛犬同伴グランピング</h3>
+    <p>ドームテントで贅沢ステイ。ドッグラン直結！</p>
+    <a href="https://www.hotel-tango-kingdom.com/theme188.html" class="btn" target="_blank">詳細ページ（外部リンク）</a>
+  </div>
+</section>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"section","className":"latest-news","layout":{"type":"constrained"}} -->
+<section id="news" class="latest-news">
+  <h2>新着情報</h2>
+  <!-- wp:query {"query":{"perPage":3,"postType":"post"},"layout":{"type":"constrained"}} -->
+  <ul>
+    <!-- wp:post-template -->
+    <li>
+      <time><!-- wp:post-date {"format":"Y.m.d"} /--></time>
+      <a href="<!-- wp:post-url /-->"><!-- wp:post-title {"level":0} /--></a>
+    </li>
+    <!-- /wp:post-template -->
+  </ul>
+  <!-- /wp:query -->
+  <p class="more"><a href="/news/">もっと見る</a></p>
+</section>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"section","className":"access-map","layout":{"type":"constrained"}} -->
+<section id="access" class="access-map">
+  <h2>アクセス</h2>
+  <div class="map-container">
+    <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3241.1080253723735!2d135.068268!3d35.674341999999996!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x5fffa4c27b6bc53b%3A0x4f7ddc708ea650ce!2z6YGT44Gu6aeFIOS4ueW-jOeOi-WbvSDpo5_jga7jgb_jgoTjgZM!5e0!3m2!1sja!2sjp!4v1750574517068!5m2!1sja!2sjp" width="100%" height="400" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
+  </div>
+</section>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
## Summary
- create block template `front-page.html`
- create header and footer template parts
- load block templates by enabling `block-templates` in theme setup

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b9978edd08329bdca2c45dd989106