### PR TITLE
Add theme.json for block editor settings

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -1,0 +1,34 @@
+{
+  "version": 2,
+  "settings": {
+    "color": {
+      "palette": [
+        { "slug": "primary", "color": "#0073aa", "name": "Primary" },
+        { "slug": "secondary", "color": "#005177", "name": "Secondary" },
+        { "slug": "contrast", "color": "#ffffff", "name": "Contrast" }
+      ]
+    },
+    "typography": {
+      "fontFamilies": [
+        { "fontFamily": "Noto Sans JP, sans-serif", "slug": "body", "name": "Body" },
+        { "fontFamily": "Noto Serif JP, serif", "slug": "heading", "name": "Heading" }
+      ],
+      "fontSizes": [
+        { "slug": "small", "size": "12px", "name": "Small" },
+        { "slug": "medium", "size": "18px", "name": "Medium" },
+        { "slug": "large", "size": "24px", "name": "Large" }
+      ]
+    },
+    "spacing": {
+      "units": [ "px", "em", "rem" ],
+      "spacingScale": {
+        "steps": 7,
+        "mediumStep": 1.5
+      }
+    },
+    "templateParts": [
+      { "name": "header", "title": "Header", "area": "header" },
+      { "name": "footer", "title": "Footer", "area": "footer" }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a basic `theme.json` with color palette, typography, spacing and template parts

## Testing
- `npm test` *(fails: could not find package.json)*
- `composer test` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b997f3cf08329b532403d567ca439